### PR TITLE
Bump golang version

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
       run: go test -v -cover --count 1 ./...
 
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,7 +41,7 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v8
       with:
-        version: v1.64.8
+        version: v2.3.0
         only-new-issues: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,5 +43,5 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.45.0
+        version: v1.64.8
         only-new-issues: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,7 @@ on:
 
 env:
   GOFLAGS: -mod=vendor
+  GO_VERSION: 1.24.4
 
 jobs:
   build:
@@ -20,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.18
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Build
       run: go build -v ./...
@@ -37,7 +38,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.18
+        go-version: ${{ env.GO_VERSION }}
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v6


### PR DESCRIPTION
- Upgrade to go 1.24
- Upgrade gha worker to 24.04
- Upgrade golangci-lint to 1.64.8
- Upgrade to golanglint-ci 2.3

Issue: VLTCLT-48
