### PR TITLE
Add WithHTTPClient option to New()

### DIFF
--- a/vaultclient/vaultclient.go
+++ b/vaultclient/vaultclient.go
@@ -32,17 +32,35 @@ const (
 	ServiceName = "iam" // Name of service.
 )
 
-func New(accessKey, secretKey, sessionToken, endpoint, region string) *Vault {
-	return &Vault{
+type Option func(*Vault)
+
+func NewHTTPClient() *http.Client {
+	return &http.Client{Timeout: 60 * time.Second}
+}
+
+func WithHTTPClient(c *http.Client) Option {
+	return func(v *Vault) {
+		if c != nil {
+			v.httpClient = c
+		}
+	}
+}
+
+func New(accessKey, secretKey, sessionToken, endpoint, region string, opts ...Option) *Vault {
+	v := &Vault{
 		endpoint:   endpoint,
 		region:     region,
-		httpClient: &http.Client{Timeout: 60 * time.Second},
+		httpClient: NewHTTPClient(),
 		creds: credentials.NewStaticCredentialsProvider(
 			accessKey,
 			secretKey,
 			sessionToken,
 		),
 	}
+	for _, opt := range opts {
+		opt(v)
+	}
+	return v
 }
 
 // makeAWSRequest is a helper function that handles AWS v4 signing and HTTP requests with retry logic

--- a/vaultclient/vaultclient_test.go
+++ b/vaultclient/vaultclient_test.go
@@ -1,0 +1,39 @@
+package vaultclient
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNewHTTPClient(t *testing.T) {
+	Convey("NewHTTPClient returns a client with the default 60s timeout", t, func() {
+		c := NewHTTPClient()
+		So(c, ShouldNotBeNil)
+		So(c.Timeout, ShouldEqual, 60*time.Second)
+	})
+}
+
+func TestNewOptions(t *testing.T) {
+	Convey("New", t, func() {
+		Convey("uses a default 60s HTTP client when no option is given", func() {
+			v := New("ak", "sk", "", "http://vault", "us-east-1")
+			So(v.httpClient, ShouldNotBeNil)
+			So(v.httpClient.Timeout, ShouldEqual, 60*time.Second)
+		})
+
+		Convey("WithHTTPClient overrides the default client", func() {
+			custom := &http.Client{Timeout: 5 * time.Second}
+			v := New("ak", "sk", "", "http://vault", "us-east-1", WithHTTPClient(custom))
+			So(v.httpClient, ShouldEqual, custom)
+		})
+
+		Convey("WithHTTPClient(nil) keeps the default client", func() {
+			v := New("ak", "sk", "", "http://vault", "us-east-1", WithHTTPClient(nil))
+			So(v.httpClient, ShouldNotBeNil)
+			So(v.httpClient.Timeout, ShouldEqual, 60*time.Second)
+		})
+	})
+}


### PR DESCRIPTION
## Summary

`New()` hardcoded its own `&http.Client{Timeout: 60s}`, so callers could not route Vault requests through an instrumented transport (e.g. for OTEL trace-context propagation).

Add a backward-compatible variadic functional option:
- `type Option func(*Vault)`
- `WithHTTPClient(c *http.Client) Option`
- `New(accessKey, secretKey, sessionToken, endpoint, region string, opts ...Option)`

The default (no option) keeps the built-in 60s client, so existing positional callers (including sorbet and pensieve-api) are unaffected.

Unblocks OS-1072 / PSVAPI-133 / https://github.com/scality/pensieve-api/pull/379 (OTEL traceparent on pensieve-api outbound clients).

Issue: VLTCLT-65